### PR TITLE
chore: prepare release 1.1.0

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -26,14 +26,14 @@ jobs:
         run: dotnet restore
 
       - name: Build solution
-        run: dotnet build --configuration Debug --no-restore
+        run: dotnet build --configuration Release --no-restore
 
       - name: Run tests
-        run: dotnet test --no-build --configuration Debug --verbosity normal
+        run: dotnet test --no-build --configuration Release --verbosity normal
 
       - name: Pack NuGet package
-        run: dotnet pack SmartStrings/SmartStrings.csproj --configuration Debug --no-build
+        run: dotnet pack SmartStrings/SmartStrings.csproj --configuration Release --no-build
 
       - name: Publish to NuGet.org
         if: startsWith(github.ref, 'refs/tags/v')
-        run: dotnet nuget push SmartStrings/bin/Debug/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push SmartStrings/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 
 ![SmartStrings logo](./SmartStrings/logo-readme.png)
 
-[![CI](https://github.com/jonatasolmartins/smart-strings/actions/workflows/nuget-publish.yml/badge.svg)](https://github.com/jonatasolmartins/smart-strings/actions/workflows/nuget-publish.yml)
 [![NuGet](https://img.shields.io/nuget/v/SmartStrings.svg)](https://www.nuget.org/packages/SmartStrings)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/SmartStrings.svg)](https://www.nuget.org/packages/SmartStrings)
+[![CI](https://github.com/jonatasolmartins/smart-strings/actions/workflows/nuget-publish.yml/badge.svg)](https://github.com/jonatasolmartins/smart-strings/actions/workflows/nuget-publish.yml)
+[![Coverage Status](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/jonatasolmartins/smart-strings)
 [![GitHub stars](https://img.shields.io/github/stars/jonatasolmartins/smart-strings.svg?style=social)](https://github.com/jonatasolmartins/smart-strings/stargazers)
 
 **SmartStrings** is a lightweight and intuitive C# string templating library. It adds extension methods like `.Fill()` that let you replace placeholders in strings using objects, dictionaries, or parameter arrays — with optional fallbacks.
@@ -23,6 +24,7 @@
   - Multiple ordered values
   - An object
   - A dictionary
+  - Nested object
 - ✅ Safe: handles `null`, missing keys, and extra placeholders gracefully
 - ✅ Works with .NET Framework (4.6.1+), .NET 6, 7, 8 and future versions
 
@@ -63,6 +65,10 @@ var result = template.Fill("Alice");
 ```csharp
 const string template = "Hello {0}, your plan is {1}";
 var result = template.Fill("Joe", "Premium");
+// Result: "Hello Joe, your plan is Premium"
+
+// Alternative
+var result = TemplateString.Fill(template, "Joe", "Premium");
 // Result: "Hello Joe, your plan is Premium"
 ```
 
@@ -108,6 +114,36 @@ var result = template.Fill(new { });
 // Result: "Hi Guest, welcome!"
 ```
 
+## ✅ 6. Manual mapping with nested model
+
+```csharp
+var card = new Card()
+{
+    User = new User() {
+        Name = "Brian",
+        Company = "SmartCo"
+    }
+};
+const string template = "Welcome {NAME} from {COMPANY}"
+
+template.Fill(card, map => {
+    map.Bind("NAME", c => c.User.Name);
+    map.Bind("COMPANY", c => c.User.Company);
+});
+// Welcome Brian from SmartCo
+```
+
+---
+
+## ✅ 7. Using TemplateString.Fill (Alternative API)
+
+```csharp
+TemplateString.Fill("Hello {USERNAME}", new { USERNAME = "Joana" });
+
+TemplateString.Fill("User: {NAME}", user, map => {
+    map.Bind("NAME", u => u.User.Name);
+});
+```
 ---
 
 ## 🧪 Supported APIs
@@ -119,11 +155,15 @@ string Fill(this string template, string value);
 // Replace all {..} in order
 string Fill(this string template, params string[] values);
 
-// Replace named placeholders with object properties
-string Fill(this string template, object values);
+/// Replaces placeholders in the template with values from a model or primitive values..
+string Fill<T>(this string template, T values);
 
 // Replace named placeholders with dictionary values
 string Fill(this string template, Dictionary<string, string?> values);
+
+// Fills a template using the flat properties of a model, allowing custom overrides for nested or formatted values.
+string Fill<T>(this string template, T model, Action<TemplateMap<T>> map)
+
 ```
 
 ---

--- a/SmartStrings.Tests/TemplateMapTests.cs
+++ b/SmartStrings.Tests/TemplateMapTests.cs
@@ -1,0 +1,297 @@
+using Shouldly;
+
+namespace SmartStrings.Tests
+{
+    public class TemplateMapTests
+    {
+        private class User
+        {
+            public Guid Id { get; set; }
+            public string? FullName { get; set; }
+        }
+
+        private class Request
+        {
+            public string? Company { get; set; }
+            public User? User { get; set; }
+        }
+
+        [Fact]
+        public void Should_Fill_With_Manually_Bound_Properties()
+        {
+            var request = new Request
+            {
+                Company = "SmartCo",
+                User = new User
+                {
+                    Id = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+                    FullName = "Jonatas"
+                }
+            };
+
+            const string template = "{USERNAME}-{COMPANY}-{ID}";
+
+            var result = template.Fill(request, map =>
+            {
+                map.Bind("USERNAME", r => r.User!.FullName);
+                map.Bind("ID", r => r.User!.Id);
+            });
+
+            result.ShouldBe("Jonatas-SmartCo-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        }
+
+        [Fact]
+        public void Should_Use_Fallback_When_Bound_Value_Is_Null()
+        {
+            var request = new Request { User = new User { FullName = null } };
+            const string template = "Welcome, {USERNAME:Guest}";
+
+            var result = template.Fill(request, map =>
+            {
+                map.Bind("USERNAME", r => r.User?.FullName);
+            });
+
+            result.ShouldBe("Welcome, Guest");
+        }
+
+        [Fact]
+        public void Should_Use_Empty_When_Bound_Value_Is_Null_And_No_Fallback()
+        {
+            var request = new Request { User = new User { FullName = null } };
+            const string template = "Welcome, {USERNAME}";
+
+            var result = template.Fill(request, map =>
+            {
+                map.Bind("USERNAME", r => r.User?.FullName);
+            });
+
+            result.ShouldBe("Welcome, ");
+        }
+
+        [Fact]
+        public void Should_Override_Flat_Object_Values_When_Manually_Bound()
+        {
+            var request = new Request
+            {
+                Company = "WrongValue",
+                User = new User { FullName = "Correct", Id = Guid.Empty }
+            };
+
+            const string template = "Company: {COMPANY}";
+
+            var result = template.Fill(request, map =>
+            {
+                map.Bind("COMPANY", _ => "SmartStrings Inc.");
+            });
+
+            result.ShouldBe("Company: SmartStrings Inc.");
+        }
+
+        [Fact]
+        public void Should_Handle_Multiple_Bindings_Correctly()
+        {
+            var newId = Guid.NewGuid();
+
+            var request = new Request
+            {
+                Company = "DevCorp",
+                User = new User { FullName = "Ana", Id = newId }
+            };
+
+            const string template = "User {USERNAME} from {COMPANY} has ID {ID}";
+
+            var result = template.Fill(request, map =>
+            {
+                map.Bind("USERNAME", r => r.User!.FullName);
+                map.Bind("COMPANY", r => r.Company);
+                map.Bind("ID", r => r.User!.Id);
+            });
+
+            result.ShouldContain($"User Ana from DevCorp has ID {newId}");
+        }
+
+        [Fact]
+        public void Should_Support_Primitive_Model()
+        {
+            const string template = "Value: {VAL}";
+
+            var result = template.Fill(123, map =>
+            {
+                map.Bind("VAL", n => n.ToString());
+            });
+
+            result.ShouldBe("Value: 123");
+        }
+
+        [Fact]
+        public void Should_Support_Single_Primitive_Value()
+        {
+            const string template = "Value: {VAL}";
+
+            var result = TemplateString.Fill(template, 123);
+
+            result.ShouldBe("Value: 123");
+        }
+
+        [Fact]
+        public void Should_Use_Fallback_For_All_Placeholders()
+        {
+            var request = new Request { User = null };
+            const string template = "User: {USERNAME:unknown}, ID: {ID:0000}, Company: {COMPANY:n/a}";
+
+            var result = template.Fill(request, map =>
+            {
+                map.Bind("USERNAME", r => r.User?.FullName);
+                map.Bind("ID", r => r.User?.Id);
+                map.Bind("COMPANY", r => r.Company);
+            });
+
+            result.ShouldBe("User: unknown, ID: 0000, Company: n/a");
+        }
+
+        [Fact]
+        public void Should_Work_With_TemplateString_Static_API()
+        {
+            var request = new Request
+            {
+                Company = "SmartBrand",
+                User = new User { Id = Guid.Empty, FullName = "Joana" }
+            };
+
+            const string template = "Hello {USERNAME} from {COMPANY}";
+
+            var result = TemplateString.Fill(template, request, map =>
+            {
+                map.Bind("USERNAME", r => r.User!.FullName);
+            });
+
+            result.ShouldBe("Hello Joana from SmartBrand");
+        }
+
+        [Fact]
+        public void Fill_WithSinglePlaceholder_ReplacesCorrectly()
+        {
+            var template = "Hello {name}";
+            var result = TemplateString.Fill(template, "John");
+            result.ShouldBe("Hello John");
+        }
+
+        [Fact]
+        public void Fill_WithMultipleValues_ReplacesInOrder()
+        {
+            var template = "Hi {0}, welcome to {1}";
+            var result = TemplateString.Fill(template, "Alice", "Wonderland");
+            result.ShouldBe("Hi Alice, welcome to Wonderland");
+        }
+
+        [Fact]
+        public void Fill_WithDictionary_ReplacesNamedPlaceholders()
+        {
+            var template = "Hello {user}, your plan is {plan}";
+            var values = new Dictionary<string, string?>
+            {
+                { "user", "Lucas" },
+                { "plan", "Premium" }
+            };
+
+            var result = TemplateString.Fill(template, values);
+            result.ShouldBe("Hello Lucas, your plan is Premium");
+        }
+
+        [Fact]
+        public void Fill_WithObject_ReplacesPlaceholdersWithPropertyValues()
+        {
+            var template = "User: {Name}, Plan: {Plan}";
+            var result = TemplateString.Fill(template, new { Name = "Joana", Plan = "Basic" });
+
+            result.ShouldBe("User: Joana, Plan: Basic");
+        }
+
+        [Fact]
+        public void Fill_WithFallback_UsesFallbackWhenKeyIsMissing()
+        {
+            var template = "Hi {name:User}, welcome!";
+            var result = TemplateString.Fill(template, new Dictionary<string, string?>());
+
+            result.ShouldBe("Hi User, welcome!");
+        }
+
+        [Fact]
+        public void Fill_WithNullValue_UsesFallback()
+        {
+            var template = "Hi {name:Guest}";
+            var result = TemplateString.Fill(template, new Dictionary<string, string?> { ["name"] = null });
+
+            result.ShouldBe("Hi Guest");
+        }
+
+        [Fact]
+        public void Fill_WithEmptyTemplate_ReturnsEmptyString()
+        {
+            var result = TemplateString.Fill("", "test");
+            result.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void Fill_WithNoPlaceholders_ReturnsOriginalString()
+        {
+            var result = TemplateString.Fill("Just a normal string", "ignored");
+            result.ShouldBe("Just a normal string");
+        }
+
+        [Fact]
+        public void Fill_WithNullTemplate_ReturnTheNullTemplate()
+        {
+            string? template = null;
+
+            var act = TemplateString.Fill(template, "value");
+            act.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Fill_WithNullObject_ReplacesWithFallbacksOrEmpty()
+        {
+            var template = "Hello {name:Guest}, welcome!";
+            object? nullValue = null;
+            var result = TemplateString.Fill(template, nullValue!);
+
+            result.ShouldBe("Hello Guest, welcome!");
+        }
+
+        [Fact]
+        public void Fill_WithExtraValues_IgnoresThem()
+        {
+            var template = "Hello {0}";
+            var result = TemplateString.Fill(template, "Alice", "Extra", "More");
+
+            result.ShouldBe("Hello Alice");
+        }
+
+        [Fact]
+        public void Fill_WithFewerValues_LeavesPlaceholderUnchanged()
+        {
+            var template = "Hello {0}, welcome to {1}";
+            var result = TemplateString.Fill(template, "Alice");
+
+            result.ShouldBe("Hello Alice, welcome to {1}");
+        }
+
+        [Fact]
+        public void Fill_WithSpecialCharactersInValues_ReplacesCorrectly()
+        {
+            var template = "Path: {path}";
+            var result = TemplateString.Fill(template, new { path = @"C:\Users\Name" });
+
+            result.ShouldBe(@"Path: C:\Users\Name");
+        }
+
+        [Fact]
+        public void Fill_WithBracesInsideValues_DoesNotBreak()
+        {
+            var template = "Log: {message}";
+            var result = TemplateString.Fill(template, new { message = "Something {weird} happened" });
+
+            result.ShouldBe("Log: Something {weird} happened");
+        }
+    }
+}

--- a/SmartStrings/README.nuget.md
+++ b/SmartStrings/README.nuget.md
@@ -13,6 +13,7 @@
   - Multiple ordered values
   - An object
   - A dictionary
+  - Nested object
 - ✅ Safe: handles `null`, missing keys, and extra placeholders gracefully
 - ✅ Works with .NET Framework (4.6.1+), .NET 6, 7, 8 and future versions
 
@@ -37,6 +38,10 @@ var result = template.Fill("Alice");
 const string template = "Hello {0}, your plan is {1}";
 var result = template.Fill("Joe", "Premium");
 // Result: "Hello Joe, your plan is Premium"
+
+// Alternative
+var result = TemplateString.Fill(template, "Joe", "Premium");
+// Result: "Hello Joe, your plan is Premium"
 ```
 
 Or using named placeholders:
@@ -52,7 +57,7 @@ var result = template.Fill("Jonatas", "Gold");
 ### ✅ 3. Using a dictionary
 
 ```csharp
-const string template = "Hi {name}, you're on the {plan} plan.";
+var template = "Hi {name}, you're on the {plan} plan.";
 var result = template.Fill(new Dictionary<string, string?>
 {
     ["name"] = "Carla",
@@ -80,6 +85,39 @@ var template = "Hi {name:Guest}, welcome!";
 var result = template.Fill(new { });
 // Result: "Hi Guest, welcome!"
 ```
+
+## ✅ 6. Manual mapping with nested model
+
+```csharp
+var card = new Card()
+{
+    User = new User() {
+        Name = "Brian",
+        Company = "SmartCo"
+    }
+};
+const string template = "Welcome {NAME} from {COMPANY}"
+
+template.Fill(card, map => {
+    map.Bind("NAME", c => c.User.Name);
+    map.Bind("COMPANY", c => c.User.Company);
+});
+// Welcome Brian from SmartCo
+```
+
+---
+
+## ✅ 7. Using TemplateString.Fill (Alternative API)
+
+```csharp
+TemplateString.Fill("Hello {USERNAME}", new { USERNAME = "Joana" });
+
+TemplateString.Fill("User: {NAME}", user, map => {
+    map.Bind("NAME", u => u.User.Name);
+});
+```
+---
+
 
 ## ✅ Compatibility
 

--- a/SmartStrings/SmartStringExtensions.cs
+++ b/SmartStrings/SmartStringExtensions.cs
@@ -13,6 +13,69 @@ namespace SmartStrings
 {
 
     /// <summary>
+    /// Provides static access to template filling methods, as an alternative to extension syntax.
+    /// </summary>
+    public static class TemplateString
+    {
+         /// <summary>
+        /// Replaces the first placeholder in the string with the provided value.
+        /// </summary>
+        /// <remarks>
+        /// Returns the original template if it is null or empty.
+        /// </remarks>
+        /// <param name="template">The template string containing a single placeholder.</param>
+        /// <param name="value">The value to insert into the template.</param>
+        /// <returns>The filled string.</returns>
+        public static string Fill(string template, string value) =>
+            SmartStringExtensions.Fill(template, value);
+
+        /// <summary>
+        /// Replaces placeholders in the string with the corresponding values in the order provided.
+        /// </summary>
+        /// <remarks>
+        /// Returns the original template if it is null or empty.
+        /// </remarks>
+        /// <param name="template">The template string containing placeholders.</param>
+        /// <param name="values">The values to insert into the placeholders in order.</param>
+        /// <returns>The filled string.</returns>
+        public static string Fill(string template, params string[] values) =>
+            SmartStringExtensions.Fill(template, values);
+
+        /// <summary>
+        /// Replaces named placeholders in the template with values from a dictionary.
+        /// Supports fallback values in the form <c>{key:fallback}</c>.
+        /// </summary>
+        /// <remarks>
+        /// Returns the original template if it is null or empty.
+        /// </remarks>
+        /// <param name="template">The template string containing named placeholders.</param>
+        /// <param name="values">A dictionary of keys and values to fill the template.</param>
+        /// <returns>The filled string with all placeholders replaced.</returns>
+        public static string Fill(string template, Dictionary<string, string?> values) =>
+            SmartStringExtensions.Fill(template, values);
+
+        /// <summary>
+        /// Replaces placeholders in the template with values from a model.
+        /// Supports both flat objects (with public properties) and primitive values.
+        /// Named placeholders support fallback values in the form <c>{key:fallback}</c>.
+        /// </summary>
+        /// <remarks>
+        /// If the model is a primitive or string, replaces the first placeholder only.
+        /// If the template is null or empty, it is returned as is.
+        /// </remarks>
+        /// <param name="template">The template string containing named or positional placeholders.</param>
+        /// <param name="values">A value or object whose data is used to fill the template.</param>
+        /// <returns>The filled string with placeholders replaced accordingly.</returns>
+        public static string Fill<T>(string template, T values) =>
+            SmartStringExtensions.Fill(template, values);
+
+        /// <summary>
+        /// Fills a template using the flat properties of a model, allowing custom overrides for nested or formatted values.
+        /// </summary>
+        public static string Fill<T>(string template, T model, Action<TemplateMap<T>> map) =>
+            SmartStringExtensions.Fill(template, model, map);
+    }
+    /// <summary>
     /// Provides extension methods for filling string templates with values.
     /// </summary>
     public static class SmartStringExtensions
@@ -84,33 +147,121 @@ namespace SmartStrings
         }
 
         /// <summary>
-        /// Replaces named placeholders in the template with values from an object's public properties.
-        /// Supports fallback values in the form <c>{key:fallback}</c>.
+        /// Replaces placeholders in the template with values from a model.
+        /// Supports both flat objects (with public properties) and primitive values.
+        /// Named placeholders support fallback values in the form <c>{key:fallback}</c>.
         /// </summary>
         /// <remarks>
-        /// Returns the original template if it is null or empty.
+        /// If the model is a primitive or string, replaces the first placeholder only.
+        /// If the template is null or empty, it is returned as is.
         /// </remarks>
-        /// <param name="template">The template string containing named placeholders.</param>
-        /// <param name="values">An object whose property names and values are used to fill the template.</param>
-        /// <returns>The filled string with placeholders replaced by property values.</returns>
-        public static string Fill(this string template, object values)
+        /// <param name="template">The template string containing named or positional placeholders.</param>
+        /// <param name="values">A value or object whose data is used to fill the template.</param>
+        /// <returns>The filled string with placeholders replaced accordingly.</returns>
+        public static string Fill<T>(this string template, T values)
         {
+
             if (string.IsNullOrEmpty(template)) return template;
 
             if (values is null)
-                values = new { placeholderRegex = "" };
+                return template.Fill(new Dictionary<string, string?>());
 
-            var type = values.GetType();
-            var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-            var dict = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            var type = typeof(T);
 
-            foreach (var prop in properties)
+            if (type.IsPrimitive || values is string || values is decimal)
             {
-                var val = prop.GetValue(values)?.ToString();
-                dict[prop.Name] = val;
+                return template.Fill(values?.ToString() ?? string.Empty);
+            }
+
+            var dict = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                dict[prop.Name] = prop.GetValue(values)?.ToString();
             }
 
             return template.Fill(dict);
+
         }
+
+
+        /// <summary>
+        /// Fills a template using the flat properties of a model, allowing custom overrides for nested or formatted values.
+        /// </summary>
+        public static string Fill<T>(this string template, T model, Action<TemplateMap<T>> map)
+        {
+            if (string.IsNullOrEmpty(template)) return string.Empty;
+
+            var baseDict = SmartStringExtensions.ExtractValues(model);
+
+            var binder = new TemplateMap<T>(model);
+            map?.Invoke(binder);
+
+            foreach (var kv in binder.GetValues())
+            {
+                baseDict[kv.Key] = kv.Value;
+            }
+
+            return template.Fill(baseDict);
+        }
+
+        /// <summary>
+        /// Extracts public instance property values from the model into a dictionary.
+        /// </summary>
+        private static Dictionary<string, string?> ExtractValues<T>(T model)
+        {
+            var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            if (model == null) return result;
+
+            var properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+
+            foreach (var prop in properties)
+            {
+                var val = prop.GetValue(model)?.ToString();
+                result[prop.Name] = val;
+            }
+
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Enables manual binding of values from a complex object to string placeholders.
+    /// </summary>
+    /// <typeparam name="T">The source object type.</typeparam>
+    public class TemplateMap<T>
+    {
+        private readonly Dictionary<string, string?> _values = new();
+
+        /// <summary>
+        /// The original source object passed to Fill.
+        /// </summary>
+        public T Source { get; }
+
+        public TemplateMap(T source)
+        {
+            Source = source;
+        }
+
+        /// Binds a value to a placeholder key.
+        /// If the resolved value is null or empty, and the template has a fallback (e.g., {KEY:Fallback}),
+        /// the fallback will be used instead.
+        /// <example>
+        /// map.Bind("USERNAME", r => r.User?.FullName);
+        /// </example>
+        public void Bind(string key, Func<T, object?> resolver)
+        {
+            _values[key] = resolver(Source)?.ToString();
+        }
+
+        /// <summary>
+        /// Binds or overrides a placeholder value manually.
+        /// </summary>
+        public string? this[string key]
+        {
+            get => _values.TryGetValue(key, out var val) ? val : null;
+            set => _values[key] = value;
+        }
+
+        internal Dictionary<string, string?> GetValues() => _values;
     }
 }

--- a/SmartStrings/SmartStrings.csproj
+++ b/SmartStrings/SmartStrings.csproj
@@ -9,7 +9,8 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
 
     <PackageId>SmartStrings</PackageId>
-    <Version>1.0.4</Version>
+    <Version>1.1.0</Version>
+    
     <Authors>Jonatas Olziris Martins</Authors>
     <Company>Jonatas Olziris Martins</Company>
     <Description>SmartStrings is a lightweight string templating library for C# with support for named placeholders, fallbacks, and object binding.</Description>


### PR DESCRIPTION
## [1.1.0] - 2025-06-19

### Added
- `Fill<T>(...)` with supporte to primitives and  complexis types
- Class `TemplateString` for use without extension
- Support to fallback on manual bindings
- more tests added